### PR TITLE
Performance testing

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -12,6 +12,7 @@ jobs:
           access_token: "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"
           store: "theme-blackbytt-poc.myshopify.com"
           lhci_min_score_accessibility: 0.9
+          lhci_min_score_performance: 0.7
           password: "saylyo"
 
           # ------------------------To be implemented with Outh2.0-----------------------------

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -9,9 +9,14 @@ jobs:
       - name: Lighthouse
         uses: shopify/lighthouse-ci-action@v1
         with:
-          access_token: ${{ secrets.SHOP_ACCESS_TOKEN }}
-          store: ${{ secrets.SHOP_STORE }}
-          password: ${{ secrets.SHOP_PASSWORD }}
-          lhci_min_score_accessibility: .9
-          lhci_github_app_token: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          access_token: "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"
+          store: "theme-blackbytt-poc.myshopify.com"
+          lhci_min_score_accessibility: 0.85
+          password: "saylyo"
 
+          # ------------------------To be implemented with Outh2.0-----------------------------
+          # access_token: ${{ secrets.SHOP_ACCESS_TOKEN }}
+          # store: ${{ secrets.SHOP_STORE }}
+          # password: ${{ secrets.SHOP_PASSWORD }}
+          # lhci_min_score_accessibility: .9
+          # lhci_github_app_token: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           access_token: "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"
           store: "theme-blackbytt-poc.myshopify.com"
-          lhci_min_score_accessibility: 0.90
+          lhci_min_score_accessibility: 0.9
           password: "saylyo"
 
           # ------------------------To be implemented with Outh2.0-----------------------------

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           access_token: "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"
           store: "theme-blackbytt-poc.myshopify.com"
-          lhci_min_score_accessibility: 0.85
+          lhci_min_score_accessibility: 0.90
           password: "saylyo"
 
           # ------------------------To be implemented with Outh2.0-----------------------------

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -12,7 +12,7 @@ jobs:
           access_token: "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"
           store: "theme-blackbytt-poc.myshopify.com"
           lhci_min_score_accessibility: 0.9
-          lhci_min_score_performance: 0.7
+          lhci_min_score_performance: 0.85
           password: "saylyo"
 
           # ------------------------To be implemented with Outh2.0-----------------------------

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -12,7 +12,7 @@ jobs:
           access_token: "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"
           store: "theme-blackbytt-poc.myshopify.com"
           lhci_min_score_accessibility: 0.9
-          lhci_min_score_performance: 0.85
+          lhci_min_score_performance: 0.7
           password: "saylyo"
 
           # ------------------------To be implemented with Outh2.0-----------------------------

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -2,14 +2,16 @@ name: Shopify Lighthouse CI
 on: [push]
 jobs:
   lhci:
-    name: Lighthouse
+    name: Lighthouse (PF_TESTING)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Lighthouse
-      uses: shopify/lighthouse-ci-action@v1
-      with:
-        access_token: "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"
-        store: "theme-blackbytt-poc.myshopify.com"
-        lhci_min_score_accessibility: 0.85
-        password: "saylyo"
+      - uses: actions/checkout@v2
+      - name: Lighthouse
+        uses: shopify/lighthouse-ci-action@v1
+        with:
+          access_token: ${{ secrets.SHOP_ACCESS_TOKEN }}
+          store: ${{ secrets.SHOP_STORE }}
+          password: ${{ secrets.SHOP_PASSWORD }}
+          lhci_min_score_accessibility: .9
+          lhci_github_app_token: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+


### PR DESCRIPTION
# Performance metric now updated to 0.9 accessibility score

As with some recent changes made to the code base via @sethijhankar, the project's performance metrics have been marked with a 0.9 accessibility score & a 0.7 performance score. To use this score ranking as a base benchmark & maintain future development to improve, I have upgraded the GitHub actions configurations to set new Performance & Accessibility metrics. (.7 & .9 respectively).

![image](https://github.com/user-attachments/assets/f260fe77-1e9a-442b-b67e-a3ca043a5279)
  

Furthermore, the commented part in the config is for future use when the tokens are replaced with repository secrets, enhancing the overall code stability & security. 